### PR TITLE
meatadata tooltip & manual alignment bug fix

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -164,9 +164,10 @@ class Controller:
         self.open_file_dialog(self.model_canvas)
 
     # add new image to storage
-    def handle_new_image(self, data, file_name):
+    def handle_new_image(self, data, file_name, metadata=None):
         storage_item = {}
         storage_item["name"] = os.path.basename(file_name)
+        storage_item['metadata'] = metadata
         self.image_count += 1
 
         storage_item["data"] = data

--- a/core/canvas.py
+++ b/core/canvas.py
@@ -1,4 +1,5 @@
 import copy
+from curses import meta
 import gc
 
 # Standard library imports
@@ -306,12 +307,13 @@ class ImageWrapper:
 
 
 # Be able to reset to first version, contrast, crop
+# use object for signal parameter if can be None
 class BaseGraphicsView(QWidget):
     image_signal = pyqtSignal(dict, bool)
     update_progress = pyqtSignal(int, str)
     error_signal = pyqtSignal(str)
     fill_metadata = pyqtSignal(dict)
-    update_manager = pyqtSignal(dict, str)
+    update_manager = pyqtSignal(dict, str, object)
     add_image_to_storage = pyqtSignal(str, object)
 
     def __init__(self, parent=None):
@@ -473,7 +475,8 @@ class BaseGraphicsView(QWidget):
             #     channel_one_image = display_image
         self.image_wrapper.data = channel_one_image
         self.image_wrapper.cmap = "default"
-        self._add_to_manager(file_name, working_channels)
+        metadata_text = metadata_widget.metadata_tooltip(metadata)
+        self._add_to_manager(file_name, working_channels, metadata_text)
         return channel_one_image
 
     def _process_single_image(
@@ -783,14 +786,14 @@ class BaseGraphicsView(QWidget):
         progress = 10 + int(channel_num / total_channels * 70)
         self.update_progress.emit(progress, f"Processing Channel {channel_num}")
 
-    def _add_to_manager(self, file_name: str, image_channels) -> None:
+    def _add_to_manager(self, file_name: str, image_channels, metadata=None) -> None:
         """Finalize processing with cleanup and emissions."""
         # self._clear_caches()
         self.update_progress.emit(100, "Image Loaded")
 
         # print("Emitting to update manager")
 
-        self.update_manager.emit(image_channels, file_name)
+        self.update_manager.emit(image_channels, file_name,metadata)
         self.image_count += 1
 
     def _clear_caches(self) -> None:
@@ -1562,6 +1565,7 @@ class MetaData(QWidget):
 
         self.table.setHorizontalHeaderLabels(["Value"])
         self.table.setColumnWidth(0, 300)
+        self.table.setStyleSheet("background-color: transparent")
 
         layout = QVBoxLayout(self)
         layout.addWidget(self.table)
@@ -1635,6 +1639,16 @@ class MetaData(QWidget):
                 metadata["DimensionOrder"] = "Unknown"
 
         return metadata
+    def metadata_tooltip(self, metadata: dict) -> str:
+        """
+        Generate a tooltip string from the metadata dictionary.
+        """
+        tooltip_lines = []
+        for key in self.headers:
+            value = metadata.get(key, "Unknown")
+            tooltip_lines.append(f"<b>{key}:</b> {value}")
+        return "<br>".join(tooltip_lines)
+
 
 
 class ImageDialog(QDialog):

--- a/models/image_list_model.py
+++ b/models/image_list_model.py
@@ -6,7 +6,6 @@ from utils import numpy_to_qimage
 
 
 class ImageTreeItem(QStandardItem):
-
     def __init__(self, uuid, channel="Channel 1", useItemName=False, image_ready=False):
         super().__init__()
         self.storage = ImageStorage()
@@ -36,6 +35,10 @@ class ImageTreeItem(QStandardItem):
                     | Qt.ItemFlag.ItemIsSelectable
                     | Qt.ItemFlag.ItemIsEditable
                 )
+                metadata_text = image_dict.get("metadata",None)
+                if metadata_text is not None:
+                    self.setData(metadata_text,Qt.ItemDataRole.ToolTipRole)
+                
             else:
                 thumbnail = QPixmap(icon).scaled(
                     30, 30, Qt.AspectRatioMode.KeepAspectRatio
@@ -47,7 +50,9 @@ class ImageTreeItem(QStandardItem):
             self.setIcon(icon)
         self.setText(text)
         self.setData(uuid, Qt.ItemDataRole.UserRole)
-        self.setData(channel, Qt.ItemDataRole.ToolTipRole)
+        self.setData(channel, Qt.ItemDataRole.WhatsThisRole)
+        
+
 
     def set_icon(self):
         """Set the icon for the item. Always a child"""

--- a/ui/ImageManager.py
+++ b/ui/ImageManager.py
@@ -209,7 +209,7 @@ class ImageTreeWidget(QTreeView):
 
                 current_default = model.itemFromIndex(item)
                 assert current_default is not None, "Current default item is None"
-                current_default = current_default.data(Qt.ItemDataRole.ToolTipRole)
+                current_default = current_default.data(Qt.ItemDataRole.WhatsThisRole)
                 if current_default is None:
                     current_default = "Channel 1"
                 children = model.itemFromIndex(item)
@@ -217,14 +217,14 @@ class ImageTreeWidget(QTreeView):
                 for i in range(children.rowCount()):
                     child_item = children.child(i)
                     assert child_item is not None, "Child item is None"
-                    channel_name = child_item.data(Qt.ItemDataRole.ToolTipRole)
+                    channel_name = child_item.data(Qt.ItemDataRole.WhatsThisRole)
                     action = QAction(channel_name, self)
                     action.setCheckable(True)
                     action.setChecked(channel_name == current_default)
                     action.triggered.connect(
                         lambda _, channel_name=channel_name: (
                             model.setData(
-                                item, channel_name, Qt.ItemDataRole.ToolTipRole
+                                item, channel_name, Qt.ItemDataRole.WhatsThisRole
                             )
                         )
                     )
@@ -282,7 +282,7 @@ class ImageTreeWidget(QTreeView):
         if tooltip is False:
             name = item.text()
         else:
-            name = item.data(Qt.ItemDataRole.ToolTipRole)
+            name = item.data(Qt.ItemDataRole.WhatsThisRole)
         item_uuid = uuid.UUID(item.data(Qt.ItemDataRole.UserRole))
         if not item_uuid:
             raise ValueError("Item does not have a valid UUID.")
@@ -294,7 +294,7 @@ class ImageTreeWidget(QTreeView):
         assert isinstance(model, ImageTreeModel), "Model is not set"
         item = model.itemFromIndex(item)
         assert item is not None, "Item is None"
-        channel = item.data(Qt.ItemDataRole.ToolTipRole)
+        channel = item.data(Qt.ItemDataRole.WhatsThisRole)
         if as_int is False:
             return str(channel)
         try:

--- a/ui/alignment/alignment_preview_dialog.py
+++ b/ui/alignment/alignment_preview_dialog.py
@@ -46,7 +46,7 @@ class ZoomableImageView(QGraphicsView):
         self._scene = QGraphicsScene(self)
         self.target_item = QGraphicsPixmapItem()
         self.moving_item = QGraphicsPixmapItem()
-        self.moving_item.setZValue(1)
+        self.moving_item.setZValue(0.5)
         self.moving_item.setOpacity(0.5)
         self._scene.addItem(self.target_item)
         self._scene.addItem(self.moving_item)
@@ -382,9 +382,9 @@ class AlignmentPreviewDialog(QDialog):
         h, w = target_gray.shape
         ah, aw = aligned_gray.shape
 
-        start_y = (ah - h) // 2
-        start_x = (aw - w) // 2
-        aligned_gray = aligned_gray[start_y : start_y + h, start_x : start_x + w]
+        # start_y = (ah - h) // 2
+        # start_x = (aw - w) // 2
+        # aligned_gray = aligned_gray[start_y : start_y + h, start_x : start_x + w]
 
         if self.adjust_contrast:
             target_gray = to_uint8(

--- a/ui/alignment/cell_layer_alignment_ui.py
+++ b/ui/alignment/cell_layer_alignment_ui.py
@@ -375,6 +375,8 @@ class CellLayerAlignmentUI(QWidget):
         )
         preview_dialog.moving_image_changed.connect(self.aligner.manually_align)
         preview_dialog.exec()
+        self.register_button.setEnabled(True)
+        self.manually_align_button.setEnabled(True)
 
     def _handle_progress(self, value, message):
         """Handle progress updates from the aligner thread"""

--- a/utils.py
+++ b/utils.py
@@ -291,57 +291,12 @@ def gaussian_kernel_1d(sigma, radius=None):
     return kernel
 
 
-
-# Dead code: This function is not used anywhere in the codebase.
-def debounce(wait_time):
-
-    """Apply separable Gaussian blur manually using numpy."""
-    kernel = gaussian_kernel_1d(sigma)
-
-    # Manual separable convolution - more efficient than apply_along_axis
-    # Horizontal pass
-    pad_width = len(kernel) // 2
-    padded = np.pad(image, ((0, 0), (pad_width, pad_width)), mode="reflect")
-    blurred_h = np.zeros_like(image)
-
-    for i in range(image.shape[0]):
-        blurred_h[i] = np.convolve(padded[i], kernel, mode="valid")
-
-    # Vertical pass
-    padded = np.pad(blurred_h, ((pad_width, pad_width), (0, 0)), mode="reflect")
-    blurred = np.zeros_like(image)
-
-    for j in range(image.shape[1]):
-        blurred[:, j] = np.convolve(padded[:, j], kernel, mode="valid")
-
-    return blurred
-
-
 def downsample(image: NDArray[np.float64], scale=0.5):
     """Downsample image by given scale factor."""
     step = int(round(1 / scale))
     return image[::step, ::step]
 
 
-def build_optical_flow_pyramid_pure_numpy(
-    image: NDArray[np.uint16], max_level=3, scale=0.5, sigma=1.0, min_size=16
-) -> List[NDArray[np.float64]]:
-    """Version using only numpy with manual separable convolution."""
-    assert image.ndim == 2, "Only grayscale images supported"
-    float_image = image.astype(np.float64)
-
-    pyramid = [float_image]
-    current = float_image
-
-    for level in range(max_level):
-        if min(current.shape) < min_size:
-            break
-
-        blurred = gaussian_blur_separable(current, sigma=sigma)
-        current = downsample(blurred, scale=scale)
-        pyramid.append(current)
-
-    return pyramid
 
 
 def adjust_contrast(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-image metadata is now preserved on import and shown as tooltips in the image list.
- Improvements
  - Image contrast auto-adjustment now uses percentile-based normalization for more consistent results.
  - Alignment preview overlay uses the full image (no center crop) for clearer comparisons.
  - Visual stacking in the alignment preview refined for better visibility.
  - Channel labels no longer appear as tooltips, reducing UI clutter.
- Bug Fixes
  - “Register Images” and “Manually Align” buttons are re-enabled after completing manual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->